### PR TITLE
#19 [FEAT] Implement GREETING-STORY-002 leap-year birthday handling

### DIFF
--- a/app/contact_repository.py
+++ b/app/contact_repository.py
@@ -1,3 +1,4 @@
+import calendar
 import sqlite3
 from datetime import date
 from pathlib import Path
@@ -27,9 +28,13 @@ class ContactRepository:
                 "contacts table contains rows with missing required fields"
             )
         month_day = today.strftime("%m-%d")
+        params = [month_day]
+        if month_day == "02-28" and not calendar.isleap(today.year):
+            params.append("02-29")
+        placeholders = ",".join("?" * len(params))
         rows = conn.execute(
-            "SELECT name, email, dob FROM contacts WHERE strftime('%m-%d', dob) = ?",
-            (month_day,),
+            f"SELECT name, email, dob FROM contacts WHERE strftime('%m-%d', dob) IN ({placeholders})",  # noqa: S608
+            params,
         ).fetchall()
         return [
             Contact(name=r[0], email=r[1], dob=date.fromisoformat(r[2])) for r in rows

--- a/tests/test_birthday_match.py
+++ b/tests/test_birthday_match.py
@@ -5,6 +5,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from app.birthday_match import is_birthday_today
+from app.contact import Contact
+from app.greeting_service import GreetingService
 
 
 # Story: GREETING-STORY-002 / Sub-story: GREETING-BE-002.1
@@ -19,3 +21,20 @@ def test_greeting_be_002_1_s1_feb29_contact_matches_feb28_in_non_leap_year():
 
     # THEN the contact is treated as a match (Feb 28 substitution applied)
     assert result is True  # nosec B101
+
+
+# Story: GREETING-STORY-002
+# Scenario: GREETING-STORY-002-S1
+def test_greeting_story_002_s1_feb29_contact_greeted_on_feb28_non_leap_year():
+    # GIVEN a contact born on Feb 29 and today is Feb 28 in a non-leap year
+    contact = Contact(name="Bob", email="bob@example.com", dob=date(1992, 2, 29))
+    today = date(2026, 2, 28)  # 2026 is not a leap year
+
+    # WHEN the birthday check is evaluated and a greeting is composed
+    matched = is_birthday_today(contact.dob, today)
+    message = GreetingService().compose(contact) if matched else None
+
+    # THEN the contact is matched and a greeting message is produced
+    assert matched is True  # nosec B101
+    assert message is not None  # nosec B101
+    assert "Bob" in message.body  # nosec B101

--- a/tests/test_birthday_match.py
+++ b/tests/test_birthday_match.py
@@ -55,3 +55,17 @@ def test_greeting_story_002_s2_feb29_contact_greeted_on_feb29_in_leap_year():
     assert matched is True  # nosec B101
     assert message is not None  # nosec B101
     assert "Carol" in message.body  # nosec B101
+
+
+# Story: GREETING-STORY-002
+# Scenario: GREETING-STORY-002-S3
+def test_greeting_story_002_s3_feb29_contact_not_matched_on_feb28_in_leap_year():
+    # GIVEN a contact born on Feb 29 and today is Feb 28 in a leap year
+    contact = Contact(name="Dave", email="dave@example.com", dob=date(1992, 2, 29))
+    today = date(2028, 2, 28)  # 2028 is a leap year
+
+    # WHEN the birthday check is evaluated
+    matched = is_birthday_today(contact.dob, today)
+
+    # THEN the contact is not matched (no substitution in a leap year)
+    assert matched is False  # nosec B101

--- a/tests/test_birthday_match.py
+++ b/tests/test_birthday_match.py
@@ -1,3 +1,4 @@
+import sqlite3
 import sys
 from datetime import date
 from pathlib import Path
@@ -6,6 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from app.birthday_match import is_birthday_today
 from app.contact import Contact
+from app.contact_repository import ContactRepository
 from app.greeting_service import GreetingService
 
 
@@ -26,18 +28,20 @@ def test_greeting_be_002_1_s1_feb29_contact_matches_feb28_in_non_leap_year():
 # Story: GREETING-STORY-002
 # Scenario: GREETING-STORY-002-S1
 def test_greeting_story_002_s1_feb29_contact_greeted_on_feb28_non_leap_year():
-    # GIVEN a contact born on Feb 29 and today is Feb 28 in a non-leap year
-    contact = Contact(name="Bob", email="bob@example.com", dob=date(1992, 2, 29))
-    today = date(2026, 2, 28)  # 2026 is not a leap year
+    # GIVEN a contact born on Feb 29 stored in the database
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE contacts (name TEXT, email TEXT, dob TEXT)")
+    conn.execute("INSERT INTO contacts VALUES (?, ?, ?)", ("Bob", "bob@example.com", "1992-02-29"))
+    conn.commit()
+    today = date(2026, 2, 28)  # non-leap year
 
-    # WHEN the birthday check is evaluated and a greeting is composed
-    matched = is_birthday_today(contact.dob, today)
-    message = GreetingService().compose(contact) if matched else None
+    # WHEN the pipeline fetches contacts and composes a greeting
+    contacts = ContactRepository(conn).get_birthday_contacts(today)
+    messages = [GreetingService().compose(c) for c in contacts]
 
-    # THEN the contact is matched and a greeting message is produced
-    assert matched is True  # nosec B101
-    assert message is not None  # nosec B101
-    assert "Bob" in message.body  # nosec B101
+    # THEN the Feb 29 contact is selected and a greeting is produced
+    assert len(messages) == 1  # nosec B101
+    assert "Bob" in messages[0].body  # nosec B101
 
 
 # Story: GREETING-STORY-002

--- a/tests/test_birthday_match.py
+++ b/tests/test_birthday_match.py
@@ -38,3 +38,20 @@ def test_greeting_story_002_s1_feb29_contact_greeted_on_feb28_non_leap_year():
     assert matched is True  # nosec B101
     assert message is not None  # nosec B101
     assert "Bob" in message.body  # nosec B101
+
+
+# Story: GREETING-STORY-002
+# Scenario: GREETING-STORY-002-S2
+def test_greeting_story_002_s2_feb29_contact_greeted_on_feb29_in_leap_year():
+    # GIVEN a contact born on Feb 29 and today is Feb 29 in a leap year
+    contact = Contact(name="Carol", email="carol@example.com", dob=date(1992, 2, 29))
+    today = date(2028, 2, 29)  # 2028 is a leap year
+
+    # WHEN the birthday check is evaluated and a greeting is composed
+    matched = is_birthday_today(contact.dob, today)
+    message = GreetingService().compose(contact) if matched else None
+
+    # THEN the contact is matched on their actual birthday and a greeting is produced
+    assert matched is True  # nosec B101
+    assert message is not None  # nosec B101
+    assert "Carol" in message.body  # nosec B101

--- a/tests/test_contact_repository.py
+++ b/tests/test_contact_repository.py
@@ -76,3 +76,24 @@ def test_contact_be_001_2_s1_row_is_mapped_to_contact_with_typed_dob():
     assert contact.email == "alice@example.com"  # nosec B101
     assert contact.dob == date(1990, 4, 17)  # nosec B101
     assert isinstance(contact.dob, date)  # nosec B101
+
+
+# Story: GREETING-STORY-002 / Scenario: GREETING-STORY-002-S1
+def test_greeting_story_002_s1_repository_returns_feb29_contact_on_feb28_non_leap_year():
+    # GIVEN a contact born on Feb 29 in the database
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE contacts (name TEXT, email TEXT, dob TEXT)")
+    conn.execute(
+        "INSERT INTO contacts VALUES (?, ?, ?)",
+        ("Bob", "bob@example.com", "1992-02-29"),
+    )
+    conn.commit()
+    today = date(2026, 2, 28)  # non-leap year
+
+    # WHEN get_birthday_contacts is called with Feb 28 in a non-leap year
+    repo = ContactRepository(conn)
+    results = repo.get_birthday_contacts(today)
+
+    # THEN the Feb 29 contact is returned (Feb 28 substitution applied in repository)
+    assert len(results) == 1  # nosec B101
+    assert results[0].name == "Bob"  # nosec B101


### PR DESCRIPTION
## Related Issue
Closes #19

## Changes
- Added `GREETING-STORY-002-S1` scenario: Feb 29 contact is matched and greeted on Feb 28 in a non-leap year
- Added `GREETING-STORY-002-S2` scenario: Feb 29 contact is matched and greeted on Feb 29 in a leap year
- Added `GREETING-STORY-002-S3` scenario: Feb 29 contact is not matched on Feb 28 in a leap year
- Fixed `contact_repository.py`: query now includes Feb 29 contacts when today is Feb 28 in a non-leap year
- Updated `test_birthday_match.py` S1 scenario to exercise the full pipeline via repository
- Added `test_contact_repository.py` S1 scenario to verify repository-level Feb 29 substitution

## Testing
- [x] Tested locally (17 tests passed)
- [x] Tests pass
- [x] Pre-commit hooks pass

## Notes
- Covers GREETING-STORY-002-S1, GREETING-STORY-002-S2, and GREETING-STORY-002-S3
- docker-test pre-commit hook skipped locally due to Docker socket permissions; CI is the gate