### PR TITLE
#21 [FEAT] Implement DELIVERY-STORY-001 email delivery

### DIFF
--- a/app/email_sender.py
+++ b/app/email_sender.py
@@ -1,0 +1,21 @@
+import os
+import smtplib
+from email.mime.text import MIMEText
+
+
+class EmailSender:
+    def __init__(self):
+        self._host = os.environ["EMAIL_HOST"]
+        self._port = int(os.environ["EMAIL_PORT"])
+        self._user = os.environ["EMAIL_USER"]
+        self._password = os.environ["EMAIL_PASSWORD"]
+        self._sender = os.environ["EMAIL_SENDER"]
+
+    def send(self, message):
+        msg = MIMEText(message.body)
+        msg["Subject"] = message.subject
+        msg["From"] = self._sender
+        msg["To"] = message.recipient
+        with smtplib.SMTP(self._host, self._port) as smtp:
+            smtp.login(self._user, self._password)
+            smtp.sendmail(self._sender, message.recipient, msg.as_string())

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ import sys
 from datetime import date
 
 from app.contact_repository import ContactRepository
+from app.email_sender import EmailSender
+from app.greeting_service import GreetingService
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -11,12 +13,27 @@ logger = logging.getLogger(__name__)
 DB_PATH = os.environ.get("DB_PATH", "contacts.db")
 
 
-def run(repo):
+def run(repo, sender=None, today=None):
+    if today is None:
+        today = date.today()
     try:
-        repo.get_birthday_contacts(date.today())
+        contacts = repo.get_birthday_contacts(today)
     except Exception as e:
         logger.error("Failed to load contacts: %s", e)
         sys.exit(1)
+
+    if sender is None:
+        sender = EmailSender()
+
+    service = GreetingService()
+    for contact in contacts:
+        try:
+            message = service.compose(contact)
+            sender.send(message)
+            logger.info("Sent greeting to %s", contact.email)
+        except Exception as e:
+            logger.error("Failed to send greeting to %s: %s", contact.email, e)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_delivery_pipeline.py
+++ b/tests/test_delivery_pipeline.py
@@ -1,0 +1,109 @@
+import logging
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.contact_repository import ContactRepository
+from app.email_sender import EmailSender
+
+ENV = {
+    "EMAIL_HOST": "smtp.example.com",
+    "EMAIL_PORT": "587",
+    "EMAIL_USER": "user@example.com",
+    "EMAIL_PASSWORD": "secret",
+    "EMAIL_SENDER": "sender@example.com",
+}
+
+
+def _make_repo(contacts):
+    """Return a ContactRepository backed by an in-memory DB seeded with contacts."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE contacts (name TEXT, email TEXT, dob TEXT)")
+    for name, email, dob in contacts:
+        conn.execute("INSERT INTO contacts VALUES (?, ?, ?)", (name, email, dob))
+    conn.commit()
+    return ContactRepository(conn)
+
+
+# Story: DELIVERY-STORY-001 / Sub-story: DELIVERY-BE-001.2
+# Scenario: DELIVERY-BE-001.2-S1
+def test_delivery_be_001_2_s1_main_calls_send_once_per_contact():
+    # GIVEN two contacts with today's birthday in the database
+    today = date(2026, 4, 21)
+    repo = _make_repo([
+        ("Alice", "alice@example.com", "1990-04-21"),
+        ("Bob", "bob@example.com", "1985-04-21"),
+    ])
+    fake_sender = MagicMock(spec=EmailSender)
+
+    # WHEN main.run() is executed
+    with patch.dict("os.environ", ENV):
+        import main
+        main.run(repo, fake_sender, today)
+
+    # THEN send is called exactly twice, once per contact
+    assert fake_sender.send.call_count == 2  # nosec B101
+
+
+# Story: DELIVERY-STORY-001 / Sub-story: DELIVERY-INFRA-001.1
+# Scenario: DELIVERY-INFRA-001.1-S2
+def test_delivery_infra_001_1_s2_missing_env_var_exits_1(capsys):
+    # GIVEN a required email env var is missing
+    incomplete_env = {k: v for k, v in ENV.items() if k != "EMAIL_PASSWORD"}
+
+    # WHEN the container starts (EmailSender is constructed)
+    with patch.dict("os.environ", incomplete_env, clear=True):
+        with patch("os.environ", incomplete_env):
+            try:
+                with patch.dict("os.environ", incomplete_env, clear=True):
+                    sender = EmailSender()
+                assert False, "expected exception not raised"  # nosec B101
+            except (KeyError, OSError, SystemExit, ValueError):
+                pass  # any of these signal a config failure
+
+
+# Story: DELIVERY-STORY-001 / Sub-story: DELIVERY-INFRA-001.3
+# Scenario: DELIVERY-INFRA-001.3-S1
+def test_delivery_infra_001_3_s1_successful_send_logs_info(caplog):
+    # GIVEN a contact with today's birthday and a working fake sender
+    today = date(2026, 4, 21)
+    repo = _make_repo([("Alice", "alice@example.com", "1990-04-21")])
+    fake_sender = MagicMock(spec=EmailSender)
+
+    # WHEN main.run() executes successfully
+    with patch.dict("os.environ", ENV):
+        import main
+        with caplog.at_level(logging.INFO):
+            main.run(repo, fake_sender, today)
+
+    # THEN an INFO log entry identifying the recipient is written
+    assert any("alice@example.com" in r.message for r in caplog.records if r.levelno == logging.INFO)  # nosec B101
+
+
+# Story: DELIVERY-STORY-001 / Sub-story: DELIVERY-INFRA-001.3
+# Scenario: DELIVERY-INFRA-001.3-S2
+def test_delivery_infra_001_3_s2_failed_send_logs_error_and_exits_1(caplog):
+    # GIVEN a contact with today's birthday and a sender that raises
+    today = date(2026, 4, 21)
+    repo = _make_repo([("Alice", "alice@example.com", "1990-04-21")])
+    fake_sender = MagicMock(spec=EmailSender)
+    fake_sender.send.side_effect = OSError("SMTP unreachable")
+
+    # WHEN main.run() encounters a send failure
+    with patch.dict("os.environ", ENV):
+        import main
+        exit_code = None
+        with caplog.at_level(logging.ERROR):
+            try:
+                main.run(repo, fake_sender, today)
+            except SystemExit as e:
+                exit_code = e.code
+
+    # THEN an ERROR log is written and the process exits with code 1
+    assert any(r.levelno == logging.ERROR for r in caplog.records)  # nosec B101
+    assert any("alice@example.com" in r.message for r in caplog.records)  # nosec B101
+    assert exit_code == 1  # nosec B101

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.email_sender import EmailSender
+from app.message import Message
+
+ENV = {
+    "EMAIL_HOST": "smtp.example.com",
+    "EMAIL_PORT": "587",
+    "EMAIL_USER": "user@example.com",
+    "EMAIL_PASSWORD": "secret",
+    "EMAIL_SENDER": "sender@example.com",
+}
+
+
+# Story: DELIVERY-STORY-001 / Sub-story: DELIVERY-BE-001.1
+# Scenario: DELIVERY-BE-001.1-S1
+def test_delivery_be_001_1_s1_send_submits_message_via_smtp():
+    # GIVEN a configured EmailSender and a Message
+    message = Message(subject="Happy Birthday!", body="Happy Birthday, Alice!", recipient="alice@example.com")
+
+    with patch("smtplib.SMTP") as mock_smtp_class:
+        mock_smtp = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_smtp)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch.dict("os.environ", ENV):
+            sender = EmailSender()
+
+            # WHEN send is called
+            sender.send(message)
+
+    # THEN the message was submitted to the SMTP server
+    mock_smtp.sendmail.assert_called_once()  # nosec B101
+
+
+# Story: DELIVERY-STORY-001 / Sub-story: DELIVERY-BE-001.1
+# Scenario: DELIVERY-BE-001.1-S2
+def test_delivery_be_001_1_s2_smtp_exception_propagates():
+    # GIVEN an EmailSender whose SMTP connection raises
+    message = Message(subject="Happy Birthday!", body="Happy Birthday, Alice!", recipient="alice@example.com")
+
+    with patch("smtplib.SMTP") as mock_smtp_class:
+        mock_smtp_class.side_effect = OSError("connection refused")
+
+        with patch.dict("os.environ", ENV):
+            sender = EmailSender()
+
+            # WHEN send is called and SMTP raises
+            # THEN the exception propagates out of EmailSender
+            try:
+                sender.send(message)
+                assert False, "expected exception was not raised"  # nosec B101
+            except OSError:
+                pass


### PR DESCRIPTION
## Related Issue
Closes #21

## Changes
- (pending) Implement `EmailSender` for DELIVERY-STORY-001
- (pending) Wire greeting composition and email sending in `main.py`
- (pending) Add tests for DELIVERY-STORY-001 delivery flow scenarios

## Testing
- [ ] Tested locally
- [ ] Tests pass
- [ ] Pre-commit hooks pass

## Notes
- Covers DELIVERY-STORY-001: happy-path email delivery end-to-end