### PR TITLE
#30 [DOCS] Complete Part 3 documentation

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,64 @@
+# Documentation CI/CD — Sphinx to GitHub Pages
+#
+# SETUP:
+#   1. Copy this file to .github/workflows/docs-deploy.yml
+#   2. Enable GitHub Pages in repo Settings → Pages → Source: GitHub Actions
+#   3. Push to main — docs will be live at https://<username>.github.io/<repo>/
+
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'docs/**'
+
+  # TODO: Uncomment to allow manual trigger
+  # workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      # TODO: If your README.md is at repo root, uncomment to copy it into docs/
+      # - name: Copy README into docs
+      #   run: cp README.md docs/README.md
+
+      - name: Build Sphinx site
+        run: sphinx-build -b html docs docs/_build/html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 __pycache__/
 *.pyc
+docs/_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,17 @@
+# Minimal makefile for Sphinx documentation
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile clean
+
+clean:
+	rm -rf $(BUILDDIR)
+
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,92 @@
+# Sphinx Documentation Starter
+
+Starter files for building a Sphinx documentation site for your kata project.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `conf.py` | Sphinx configuration — update project name, author, GitHub URL |
+| `index.rst` | Main index — add your architecture chapters and user story files |
+| `requirements.txt` | Python dependencies for Sphinx |
+| `Makefile` | Build commands (`make html`, `make clean`) |
+| `docs-deploy.yml` | GitHub Actions workflow — copy to `.github/workflows/` |
+
+## Setup
+
+### 1. Copy to your docs folder
+
+```bash
+cp -r modules/module-6-project/starter/* docs/
+```
+
+### 2. Edit `conf.py`
+
+Replace the TODO placeholders:
+
+```python
+project = "Mars Rover"              # Your kata name
+copyright = "2026, Your Name"       # Your name
+author = "Your Name"                # Your name
+
+html_theme_options = {
+    "project_name": "Mars Rover",   # Your kata name
+    "github_url": "https://github.com/YOUR_USERNAME/YOUR_REPO",
+}
+```
+
+### 3. Edit `index.rst`
+
+Update the toctree entries to match your actual file paths:
+
+```rst
+.. toctree::
+   :caption: Architecture:
+
+   architecture/01-introduction-and-goals
+   architecture/02-constraints
+   ...
+
+.. toctree::
+   :caption: User Stories:
+
+   user-stories/README
+   user-stories/rover-control
+   user-stories/grid-map
+```
+
+### 4. Install dependencies and build
+
+```bash
+pip install -r docs/requirements.txt
+cd docs && make html
+```
+
+### 5. Preview locally
+
+```bash
+open docs/_build/html/index.html
+# or
+python -m http.server -d docs/_build/html 8000
+```
+
+## GitHub Pages Deployment
+
+1. Copy the workflow file:
+
+```bash
+mkdir -p .github/workflows
+cp modules/module-6-project/starter/docs-deploy.yml .github/workflows/docs-deploy.yml
+```
+
+2. Enable GitHub Pages via CLI:
+
+```bash
+gh api repos/{owner}/{repo}/pages -X PUT -f build_type=workflow
+```
+
+Or manually: **Settings → Pages → Source → GitHub Actions**
+
+3. Push to `main` — the workflow triggers on changes to `README.md` or `docs/**`
+
+4. Your site will be live at `https://<username>.github.io/<repo-name>/`

--- a/docs/architecture
+++ b/docs/architecture
@@ -1,0 +1,1 @@
+../architecture

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,38 @@
+"""Sphinx configuration file for Kata documentation."""
+
+# -- Project information -----------------------------------------------------
+project = "Birthday Greetings"
+copyright = "2026, Aleksandar Cetkovic"
+author = "Aleksandar Cetkovic"
+release = "1.0.0"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "sphinx_wagtail_theme",
+    "myst_parser",
+    "sphinx_new_tab_link",
+]
+
+new_tab_link_show_external_link_icon = True
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = "sphinx_wagtail_theme"
+
+html_theme_options = {
+    "project_name": "Birthday Greetings",
+    "github_url": "https://github.com/cetko4/sdp-powered-by-ai-agents-aleksandar-cetkovic",
+    "footer_links": "",
+}
+
+html_show_copyright = True
+html_last_updated_fmt = "%b %d, %Y"
+html_show_sphinx = False
+
+# -- MyST Parser configuration -----------------------------------------------
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "tasklist",
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,43 @@
+Birthday Greetings Documentation
+==================================
+
+Automatically sends birthday greeting emails to contacts on their birthday.
+Built as a kata for the Software Development Processes Powered by AI Agents course.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Overview:
+
+   README
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Architecture:
+
+   architecture/01-introduction-and-goals
+   architecture/02-constraints
+   architecture/03-context-and-scope
+   architecture/04-solution-strategy
+   architecture/05-building-block-view
+   architecture/06-runtime-view
+   architecture/07-deployment-view
+   architecture/08-cross-cutting-concepts
+   architecture/09-architecture-decisions
+   architecture/10-quality-requirements
+   architecture/11-risks-and-technical-debts
+   architecture/12-glossary
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Stories:
+
+   user-stories/README
+   user-stories/contact
+   user-stories/greeting
+   user-stories/delivery
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+myst-parser>=2.0.0
+sphinx>=7.0.0
+sphinx-new-tab-link>=0.2.0
+sphinx-wagtail-theme>=6.0.0


### PR DESCRIPTION
## Related Issue
Closes #30

## Changes
- Add Sphinx setup (`docs/conf.py`, `docs/index.rst`, `docs/Makefile`, `docs/requirements.txt`)
- Add `docs/architecture/` with arc42 chapters
- Add `docs/user-stories/` with story bundles and README inventory
- Add GitHub Actions workflow for docs deploy to GitHub Pages
- Exclude `docs/_build/` from version control

## Testing
- [ ] Tested locally
- [ ] Tests pass
- [ ] Pre-commit hooks pass

## Notes
- GitHub Pages must be configured to deploy from GitHub Actions after merge